### PR TITLE
ci: creating pre-releases using the CI bot

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -197,6 +197,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/heads/main')
         with:
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           tag_name: "v${{ needs.library-version.outputs.library_version }}"
           name: "v${{ needs.library-version.outputs.library_version }}"
           prerelease: true


### PR DESCRIPTION
As requested by @sashankh01 - the CI bot will have to be the one creating the releases since elevated permissions are required to create tags... and GH's workflow token won't have them