### PR TITLE
Add backward compatibility tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -64,6 +64,19 @@ jobs:
       hps-version: ${{ inputs.hps-version || 'latest-dev' }}
     secrets: inherit # pass all secrets
 
+  backward-compatibility-tests:
+    strategy:
+      matrix:
+          hps-version: ['v1.2.0', 'v1.3.45']
+      fail-fast: false
+    uses: ansys/pyhps/.github/workflows/tests.yml@main
+    with:
+      runner: "public-ubuntu-latest-8-cores"
+      docker-compose-profiles: "backend"
+      hps-version: ${{ matrix.hps-version }}
+      upload-coverage: false
+    secrets: inherit # pass all secrets
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
To cover compatibility with released HPS versions (1.2, 1.3). Doesn't mean we can't break compatibility going forward, but we would do it very explicitly.  