### PR TITLE
logging improvements

### DIFF
--- a/src/ansys/hps/data_transfer/client/binary.py
+++ b/src/ansys/hps/data_transfer/client/binary.py
@@ -414,7 +414,7 @@ class Binary:
                     log.debug(f"Environment: {env_str}")
 
                 with PrepareSubprocess():
-                    log.info("Launching data transfer worker") 
+                    log.info("Launching data transfer worker")
                     self._process = subprocess.Popen(
                         args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
                     )


### PR DESCRIPTION
This pull request introduces additional logging to the data transfer client, making it easier to monitor the process lifecycle and diagnose issues. The changes focus on improving visibility when the worker process is started and when it is running.

Process monitoring improvements:

* Added an info-level log message indicating the restart counter value when the data transfer process is starting in `_monitor` (`src/ansys/hps/data_transfer/client/binary.py`).
* Added an info-level log message before launching the data transfer worker, and another log message displaying the worker's PID after the process is started in `_monitor` (`src/ansys/hps/data_transfer/client/binary.py`).
* Changed the subprocess to redirect `stderr` to `stdout` for unified output stream handling in `_monitor` (`src/ansys/hps/data_transfer/client/binary.py`).

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.