### PR TITLE
Adjust multiprocessing test and correct passing through process barrier

### DIFF
--- a/src/ansys/hps/data_transfer/client/binary.py
+++ b/src/ansys/hps/data_transfer/client/binary.py
@@ -308,7 +308,7 @@ class Binary:
         del state["_stop"]
         del state["_prepared"]
         del state["_process"]
-        # del state["_log_thread"]
+        del state["_log_thread"]
         return state
 
     @property

--- a/tests/mp_test.py
+++ b/tests/mp_test.py
@@ -54,7 +54,6 @@ def _test_mp_support(ctx, client):
     while client.binary._log_thread is None:
         log.info("Waiting for logging thread to start...")
         time.sleep(1)
-    time.sleep(5)
 
     p = ctx.Process(target=_check_storage, args=(api,))
     p.start()
@@ -75,7 +74,6 @@ async def _test_async_mp_support(ctx, async_client):
     while async_client.binary._log_thread is None:
         log.info("Waiting for logging thread to start...")
         asyncio.sleep(1)
-    asyncio.sleep(5)
 
     p = ctx.Process(target=_async_check_storage, args=(api,))
     p.start()


### PR DESCRIPTION
## Description
This pull request introduces improvements to the multiprocessing support tests for both synchronous and asynchronous data transfer APIs. The main updates include adding explicit tests for different multiprocessing contexts, ensuring the logging thread is started before forking processes, and a minor internal state cleanup in the binary client.

**Multiprocessing and Async Multiprocessing Test Improvements:**

* Refactored multiprocessing tests to use explicit multiprocessing contexts (`fork` and `spawn`) and added separate test functions for each context in `tests/mp_test.py`. This ensures compatibility and correct behavior across different platforms and process start methods.
* Updated test functions to wait for the logging thread (`_log_thread`) to start before creating subprocesses, improving test reliability especially in slower environments. [[1]](diffhunk://#diff-8363dcccf07f4bf10e2979f979fe58fb64b23b531199494755fc709fe552fe28L47-R58) [[2]](diffhunk://#diff-8363dcccf07f4bf10e2979f979fe58fb64b23b531199494755fc709fe552fe28L61-R104)
* Added `time` import for synchronous waiting and used `asyncio.sleep` for asynchronous waiting in tests. [[1]](diffhunk://#diff-8363dcccf07f4bf10e2979f979fe58fb64b23b531199494755fc709fe552fe28R32) [[2]](diffhunk://#diff-8363dcccf07f4bf10e2979f979fe58fb64b23b531199494755fc709fe552fe28L61-R104)

**Internal State Management:**

* Updated the `__getstate__` method of `BinaryClient` to remove the `_log_thread` attribute from the pickled state, preventing issues when serializing/deserializing the client in multiprocessing scenarios.

## Checklist
- [ ] I have tested these changes locally.
- [ ] I have added unit tests (if appropriate).
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have linked the issue(s) addressed by this PR if any.