### PR TITLE
Fix errors with long file transfers getting "timed out".

### DIFF
--- a/src/ansys/hps/data_transfer/client/api/api.py
+++ b/src/ansys/hps/data_transfer/client/api/api.py
@@ -198,7 +198,9 @@ class DataTransferApi:
         params = {"ids": ids}
         if expand:
             params["expand"] = "true"
-        resp = self.client.session.get(url, params=params, timeout=1)
+        # We need to timeout fairly quickly here, since the call is expected to be made and return very quickly.  
+        # If its not, we want to know when its not working properly with some timeout messages.
+        resp = self.client.session.get(url, params=params, timeout=2)
         json = resp.json()
         return OperationsResponse(**json).operations
 
@@ -285,6 +287,8 @@ class DataTransferApi:
         json = resp.json()
         return OperationIdResponse(**json)
 
+    # Short operations need a short time, but some larger operations will be spammed 
+    # by too many calls over their lifetime of minutes, so work up to at least 5 seconds by default.
     def wait_for(
         self,
         operation_ids: builtins.list[str | Operation | OperationIdResponse],

--- a/src/ansys/hps/data_transfer/client/api/api.py
+++ b/src/ansys/hps/data_transfer/client/api/api.py
@@ -340,7 +340,6 @@ class DataTransferApi:
                     break
             except (TimeoutException, TimeoutError):
                 log.debug("Operations status call timed out, retrying...")
-                continue
             except Exception as e:
                 log.debug(f"Error getting operations: {e}")
                 if raise_on_error:

--- a/src/ansys/hps/data_transfer/client/api/api.py
+++ b/src/ansys/hps/data_transfer/client/api/api.py
@@ -28,12 +28,12 @@ data transfer operations, managing resources, and handling client interactions.
 
 import builtins
 from collections.abc import Callable
-from httpx import TimeoutException
 import logging
 import time
 import traceback
 
 import backoff
+from httpx import TimeoutException
 
 from ..client import Client
 from ..exceptions import TimeoutError
@@ -198,7 +198,7 @@ class DataTransferApi:
         params = {"ids": ids}
         if expand:
             params["expand"] = "true"
-        # We need to timeout fairly quickly here, since the call is expected to be made and return very quickly.  
+        # We need to timeout fairly quickly here, since the call is expected to be made and return very quickly.
         # If its not, we want to know when its not working properly with some timeout messages.
         resp = self.client.session.get(url, params=params, timeout=2)
         json = resp.json()
@@ -287,7 +287,7 @@ class DataTransferApi:
         json = resp.json()
         return OperationIdResponse(**json)
 
-    # Short operations need a short time, but some larger operations will be spammed 
+    # Short operations need a short time, but some larger operations will be spammed
     # by too many calls over their lifetime of minutes, so work up to at least 5 seconds by default.
     def wait_for(
         self,
@@ -338,7 +338,7 @@ class DataTransferApi:
                 if all(op.state in [OperationState.Succeeded, OperationState.Failed] for op in ops):
                     log.debug("All operations have completed.")
                     break
-            except TimeoutException or TimeoutError:
+            except (TimeoutException, TimeoutError):
                 log.debug("Operations status call timed out, retrying...")
                 continue
             except Exception as e:

--- a/src/ansys/hps/data_transfer/client/api/api.py
+++ b/src/ansys/hps/data_transfer/client/api/api.py
@@ -339,7 +339,7 @@ class DataTransferApi:
                     log.debug("All operations have completed.")
                     break
             except TimeoutException or TimeoutError:
-                log.debug("Operations call timed out, retrying...")
+                log.debug("Operations status call timed out, retrying...")
                 continue
             except Exception as e:
                 log.debug(f"Error getting operations: {e}")

--- a/src/ansys/hps/data_transfer/client/api/api.py
+++ b/src/ansys/hps/data_transfer/client/api/api.py
@@ -28,6 +28,7 @@ data transfer operations, managing resources, and handling client interactions.
 
 import builtins
 from collections.abc import Callable
+from httpx import TimeoutException
 import logging
 import time
 import traceback
@@ -289,7 +290,7 @@ class DataTransferApi:
         operation_ids: builtins.list[str | Operation | OperationIdResponse],
         timeout: float | None = None,
         interval: float = 0.1,
-        cap: float = 2.0,
+        cap: float = 5.0,
         raise_on_error: bool = False,
         handler: Callable[[builtins.list[Operation]], None] = None,
     ):
@@ -333,6 +334,9 @@ class DataTransferApi:
                 if all(op.state in [OperationState.Succeeded, OperationState.Failed] for op in ops):
                     log.debug("All operations have completed.")
                     break
+            except TimeoutException or TimeoutError:
+                log.debug("Operations call timed out, retrying...")
+                continue
             except Exception as e:
                 log.debug(f"Error getting operations: {e}")
                 if raise_on_error:

--- a/src/ansys/hps/data_transfer/client/api/async_api.py
+++ b/src/ansys/hps/data_transfer/client/api/async_api.py
@@ -259,7 +259,6 @@ class AsyncDataTransferApi:
                     break
             except (TimeoutException, TimeoutError):
                 log.debug("Operations status call timed out, retrying...")
-                continue
             except Exception as e:
                 log.debug(f"Error getting operations: {e}")
                 if raise_on_error:

--- a/src/ansys/hps/data_transfer/client/api/async_api.py
+++ b/src/ansys/hps/data_transfer/client/api/async_api.py
@@ -35,6 +35,7 @@ import time
 import traceback
 
 import backoff
+from httpx import TimeoutException
 import humanize as hz
 
 from ..client import AsyncClient
@@ -150,7 +151,7 @@ class AsyncDataTransferApi:
         params = {"ids": ids}
         if expand:
             params["expand"] = "true"
-        resp = await self.client.session.get(url, params=params)
+        resp = await self.client.session.get(url, params=params, timeout=2)
         json = resp.json()
         return OperationsResponse(**json).operations
 
@@ -211,7 +212,7 @@ class AsyncDataTransferApi:
         operation_ids: builtins.list[str | Operation],
         timeout: float | None = None,
         interval: float = 0.1,
-        cap: float = 2.0,
+        cap: float = 5.0,
         raise_on_error: bool = False,
         handler: Callable[[builtins.list[Operation]], Awaitable[None]] = None,
     ):
@@ -256,6 +257,9 @@ class AsyncDataTransferApi:
 
                 if all(op.state in [OperationState.Succeeded, OperationState.Failed] for op in ops):
                     break
+            except (TimeoutException, TimeoutError):
+                log.debug("Operations status call timed out, retrying...")
+                continue
             except Exception as e:
                 log.debug(f"Error getting operations: {e}")
                 if raise_on_error:


### PR DESCRIPTION
## Description
wait_for can timeout and cause the whole copy to fail because it can throw a "timed out" error which stops us from monitoring it.
This is observed mostly when uploading really large files that take a long time to upload, where many operations calls are made to check its status, and sometimes the response is not quick.

This pull request makes several improvements to the operation polling and error handling logic in the `api.py` client. The changes focus on making timeout handling more robust, improving logging for timeouts, and adjusting polling intervals for better performance during longer operations.

**Timeout and error handling improvements:**

* Added import for `TimeoutException` from `httpx` and included it in the exception handling for operation polling, so timeouts are now logged and retried instead of causing failures. [[1]](diffhunk://#diff-a61664cd7afcc787dae1e1139ce6556164c389cd7a3a738b039b98f2f0de50d1R36) [[2]](diffhunk://#diff-a61664cd7afcc787dae1e1139ce6556164c389cd7a3a738b039b98f2f0de50d1R341-R343)

**Polling interval and timeout adjustments:**

* Increased the timeout for the `_operations` status call from 1 second to 2 seconds to reduce false positives for timeouts during normal operation.
* Increased the default polling interval cap in `wait_for` from 2 seconds to 5 seconds, allowing longer-running operations to be polled less aggressively and reducing server load.

## Checklist
- [ ] I have tested these changes locally.
- [ ] I have added unit tests (if appropriate).
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have linked the issue(s) addressed by this PR if any.