### PR TITLE
Add a callable action after release to trigger the update_tag workflow in rep-deployments

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -274,6 +274,22 @@ jobs:
           library-name: ${{ env.PACKAGE_NAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  update-deployments:
+    name: Update deployments
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          fetch-depth: 0
+      - name: Publish
+        uses: ansys-internal/hps-github-actions/.github/actions/update_rep_deployments_tag@main
+        with:
+          github-token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          package: data_transfer_py
+
   doc-deploy-stable:
     name: "Deploy stable documentation"
     # Deploy release documentation when creating a new tag


### PR DESCRIPTION
## Description
Please provide a brief description of the changes in this pull request.

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.