### PR TITLE
Delete existing pile of old artifacts on pre-release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -217,22 +217,13 @@ jobs:
       - name: List artifacts
         run: ls -ltR /tmp/artifacts
 
-      - name: Delete existing assets on pre-release
+      - name: Delete existing pre-release
         env:
           GH_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           TAG: "v${{ needs.library-version.outputs.library_version }}"
           REPO: ${{ github.repository }}
         run: |
-          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
-            echo "Cleaning up assets on existing pre-release $TAG"
-            mapfile -t assets < <(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')
-            for asset in "${assets[@]}"; do
-              echo "Deleting asset: $asset"
-              gh release delete-asset "$TAG" "$asset" --repo "$REPO" --yes
-            done
-          else
-            echo "No existing release for $TAG; nothing to clean."
-          fi
+          gh release delete "$TAG" --repo "$REPO" --cleanup-tag --yes || true
 
       - name: Release to latest-dev
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -217,6 +217,23 @@ jobs:
       - name: List artifacts
         run: ls -ltR /tmp/artifacts
 
+      - name: Delete existing assets on pre-release
+        env:
+          GH_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          TAG: "v${{ needs.library-version.outputs.library_version }}"
+          REPO: ${{ github.repository }}
+        run: |
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Cleaning up assets on existing pre-release $TAG"
+            mapfile -t assets < <(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')
+            for asset in "${assets[@]}"; do
+              echo "Deleting asset: $asset"
+              gh release delete-asset "$TAG" "$asset" --repo "$REPO" --yes
+            done
+          else
+            echo "No existing release for $TAG; nothing to clean."
+          fi
+
       - name: Release to latest-dev
         uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/heads/main')


### PR DESCRIPTION
## Description
This pull request adds a new step to the CI/CD workflow to ensure that any existing assets on a pre-release are deleted before uploading new ones. This helps prevent conflicts and ensures that only the latest assets are attached to the pre-release.

softprops/action-gh-release only updates the file we are uploading

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.