### PR TITLE
Capitalization is breaking token logging

### DIFF
--- a/src/ansys/hps/data_transfer/client/binary.py
+++ b/src/ansys/hps/data_transfer/client/binary.py
@@ -121,7 +121,7 @@ def default_log_message(debug: bool, data: dict[str, any]):
     if msg is None:
         return
 
-    msg = msg.capitalize()
+    # msg = msg.capitalize()
     level_no = level_map.get(level, logging.INFO)
     other = ""
     for k, v in data.items():


### PR DESCRIPTION
## Description
 The capitalization should not be handled for all messages, instead allow things like tokens to be capitalized as necessary.

## Checklist
- [ ] I have tested these changes locally.
- [ ] I have added unit tests (if appropriate).
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have linked the issue(s) addressed by this PR if any.