### PR TITLE
Add HPS 1.5.12 to backward compatibility tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,6 +15,7 @@ on:
             - 'v1.2.0'
             - 'v1.3.45'
             - 'v1.4.10'
+            - 'v1.5.12'
             - 'latest-dev'
 
   push:
@@ -68,7 +69,7 @@ jobs:
   backward-compatibility-tests:
     strategy:
       matrix:
-          hps-version: ['v1.2.0', 'v1.3.45', 'v1.4.10']
+          hps-version: ['v1.2.0', 'v1.3.45', 'v1.4.10', 'v1.5.12']
       fail-fast: false
     uses: ansys/pyhps/.github/workflows/tests.yml@main
     with:


### PR DESCRIPTION
## Description
Add HPS 1.5.12 to backward compatibility tests

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.