### PR TITLE
Use API key embedded in auth token

### DIFF
--- a/src/ansys/hps/data_transfer/client/binary.py
+++ b/src/ansys/hps/data_transfer/client/binary.py
@@ -117,7 +117,7 @@ def default_log_message(debug: bool, data: dict[str, any]):
         data.pop("caller", None)
         data.pop("mode", None)
     source = data.pop("source", None)
-    sourceStr = f"{source.get('file', '')}:{source.get('line', '')}" if source else ""
+    source_str = f"{source.get('file', '')}:{source.get('line', '')}" if source else ""
     msg = data.pop("msg", None)
 
     if msg is None:
@@ -132,8 +132,8 @@ def default_log_message(debug: bool, data: dict[str, any]):
     other = other.strip()
 
     full_msg = "File Transfer"
-    if sourceStr and debug:
-        full_msg += f" ({sourceStr})"
+    if source_str and debug:
+        full_msg += f" ({source_str})"
     full_msg = f"{full_msg}: {msg}"
     if other:
         full_msg += f" {other}"

--- a/src/ansys/hps/data_transfer/client/binary.py
+++ b/src/ansys/hps/data_transfer/client/binary.py
@@ -109,14 +109,16 @@ def default_log_message(debug: bool, data: dict[str, any]):
     data : dict
         Data to log.
     """
-    # log.warning(f"Worker: {d}")
+    # log.warning(f"Worker: {data}")
 
     level = data.pop("level", "info")
     data.pop("time", None)
     if not debug:
         data.pop("caller", None)
         data.pop("mode", None)
-    msg = data.pop("message", None)
+    source = data.pop("source", None)
+    sourceStr = f"{source.get('file', '')}:{source.get('line', '')}" if source else ""
+    msg = data.pop("msg", None)
 
     if msg is None:
         return
@@ -128,10 +130,16 @@ def default_log_message(debug: bool, data: dict[str, any]):
         formatted_value = f'"{v}"' if isinstance(v, str) and " " in v else v
         other += f"{k}={formatted_value} "
     other = other.strip()
+
+    full_msg = "File Transfer"
+    if sourceStr and debug:
+        full_msg += f" ({sourceStr})"
+    full_msg = f"{full_msg}: {msg}"
     if other:
-        msg += f" {other}"
-    msg = msg.encode("ascii", errors="ignore").decode().strip()
-    log.log(level_no, f"File Transfer: {msg}")
+        full_msg += f" {other}"
+
+    full_msg = full_msg.encode("ascii", errors="ignore").decode().strip()
+    log.log(level_no, full_msg)
 
 
 class BinaryConfig:

--- a/src/ansys/hps/data_transfer/client/client.py
+++ b/src/ansys/hps/data_transfer/client/client.py
@@ -45,7 +45,7 @@ import urllib3
 
 from ansys.hps.data_transfer.client.binary import Binary, BinaryConfig
 from ansys.hps.data_transfer.client.exceptions import BinaryError, async_raise_for_status, raise_for_status
-from ansys.hps.data_transfer.client.token import prepare_token
+from ansys.hps.data_transfer.client.token import prepare_token, token_is_api_key
 
 urllib3.disable_warnings()
 
@@ -561,6 +561,9 @@ class ClientBase:
         Automatically refreshes the access token and
         re-sends the request in case of an unauthorized error.
         """
+        if self._bin_config.auth_type not in ["oidc", "token-service"]:
+            return
+
         log.debug(f"response status: {response.status_code} for {response.request.method} {response.url}")
         if response.status_code == 401 and self._unauthorized_num_retry < self._unauthorized_max_retry:
             log.info("401 authorization error: Trying to get a new access token.")
@@ -589,6 +592,9 @@ class ClientBase:
         Automatically refreshes the access token and
         re-sends the request in case of an unauthorized error.
         """
+        if self._bin_config.auth_type not in ["oidc", "token-service"]:
+            return
+
         log.debug(f"response status: {response.status_code} for {response.request.method} {response.url}")
         if response.status_code == 401 and self._unauthorized_num_retry < self._unauthorized_max_retry:
             log.info("401 authorization error: Trying to get a new access token.")
@@ -617,9 +623,14 @@ class ClientBase:
 
         if self.has("auth_types.api_key"):
             self._bin_config.auth_type = "api-key"
-            self._api_key = "".join(
-                random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(128)
-            )
+            if self._bin_config.token is not None and token_is_api_key(self._bin_config.token):
+                log.debug("Using API key embedded in auth token")
+                self._api_key = self._bin_config.token[len("ApiKey ") :]
+            else:
+                log.debug("Generating random API key" )
+                self._api_key = "".join(
+                    random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(128)
+                )
             env = {
                 api_key_header_env: self._api_key_header,
                 api_key_value_env: self._api_key,

--- a/src/ansys/hps/data_transfer/client/client.py
+++ b/src/ansys/hps/data_transfer/client/client.py
@@ -627,7 +627,7 @@ class ClientBase:
                 log.debug("Using API key embedded in auth token")
                 self._api_key = self._bin_config.token[len("ApiKey ") :]
             else:
-                log.debug("Generating random API key" )
+                log.debug("Generating random API key")
                 self._api_key = "".join(
                     random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(128)
                 )

--- a/src/ansys/hps/data_transfer/client/client.py
+++ b/src/ansys/hps/data_transfer/client/client.py
@@ -561,7 +561,7 @@ class ClientBase:
         Automatically refreshes the access token and
         re-sends the request in case of an unauthorized error.
         """
-        if self._bin_config.auth_type not in ["oidc", "token-service"]:
+        if self._bin_config.auth_type not in ["api-key"]:
             return
 
         log.debug(f"response status: {response.status_code} for {response.request.method} {response.url}")
@@ -592,7 +592,7 @@ class ClientBase:
         Automatically refreshes the access token and
         re-sends the request in case of an unauthorized error.
         """
-        if self._bin_config.auth_type not in ["oidc", "token-service"]:
+        if self._bin_config.auth_type not in ["api-key"]:
             return
 
         log.debug(f"response status: {response.status_code} for {response.request.method} {response.url}")

--- a/src/ansys/hps/data_transfer/client/client.py
+++ b/src/ansys/hps/data_transfer/client/client.py
@@ -561,7 +561,7 @@ class ClientBase:
         Automatically refreshes the access token and
         re-sends the request in case of an unauthorized error.
         """
-        if self._bin_config.auth_type not in ["api-key"]:
+        if self._bin_config.auth_type in ["api-key"]:
             return
 
         log.debug(f"response status: {response.status_code} for {response.request.method} {response.url}")
@@ -592,7 +592,7 @@ class ClientBase:
         Automatically refreshes the access token and
         re-sends the request in case of an unauthorized error.
         """
-        if self._bin_config.auth_type not in ["api-key"]:
+        if self._bin_config.auth_type in ["api-key"]:
             return
 
         log.debug(f"response status: {response.status_code} for {response.request.method} {response.url}")

--- a/src/ansys/hps/data_transfer/client/token.py
+++ b/src/ansys/hps/data_transfer/client/token.py
@@ -22,8 +22,9 @@
 
 """Provides a utility function for handling authentication tokens."""
 
-API_KEY_PREFIX="ApiKey "
-BEARER_PREFIX="Bearer "
+API_KEY_PREFIX = "ApiKey "
+BEARER_PREFIX = "Bearer "
+
 
 def prepare_token(token):
     """Prepare an authentication token by ensuring it is prefixed with ``Bearer``."""
@@ -33,9 +34,10 @@ def prepare_token(token):
         token = f"Bearer {token}"
     return token
 
+
 def token_is_bearer(token):
     return token.lower().startswith(BEARER_PREFIX.lower())
 
+
 def token_is_api_key(token):
     return token.lower().startswith(API_KEY_PREFIX.lower())
-    

--- a/src/ansys/hps/data_transfer/client/token.py
+++ b/src/ansys/hps/data_transfer/client/token.py
@@ -22,12 +22,20 @@
 
 """Provides a utility function for handling authentication tokens."""
 
+API_KEY_PREFIX="ApiKey "
+BEARER_PREFIX="Bearer "
 
 def prepare_token(token):
     """Prepare an authentication token by ensuring it is prefixed with ``Bearer``."""
     if token is None:
         return None
-    tkn = token
-    if not tkn.startswith("Bearer"):
-        tkn = f"Bearer {tkn}"
-    return tkn
+    if not token_is_bearer(token) and not token_is_api_key(token):
+        token = f"Bearer {token}"
+    return token
+
+def token_is_bearer(token):
+    return token.lower().startswith(BEARER_PREFIX.lower())
+
+def token_is_api_key(token):
+    return token.lower().startswith(API_KEY_PREFIX.lower())
+    

--- a/src/ansys/hps/data_transfer/client/token.py
+++ b/src/ansys/hps/data_transfer/client/token.py
@@ -36,8 +36,10 @@ def prepare_token(token):
 
 
 def token_is_bearer(token):
+    """Check whether the token is prefixed with ``Bearer``."""
     return token.lower().startswith(BEARER_PREFIX.lower())
 
 
 def token_is_api_key(token):
+    """Check whether the token is prefixed with ``ApiKey``."""
     return token.lower().startswith(API_KEY_PREFIX.lower())


### PR DESCRIPTION
## Summary
- If an API key is embedded in the auth token (`ApiKey ...` prefix), use it directly instead of generating a random one.
- Skip the 401 auth-retry/token-refresh logic when the client isn't using `oidc`/`token-service` auth.
- Fix worker logging.
