### PR TITLE
Support no auth

### DIFF
--- a/src/ansys/hps/data_transfer/client/binary.py
+++ b/src/ansys/hps/data_transfer/client/binary.py
@@ -167,6 +167,11 @@ class BinaryConfig:
         Whether to ignore SSL certificate verification.
     debug: bool, default: False
         Whether to enable debug logging.
+    auth_type: str, default: None
+        Authentication type to pass to the worker, for example ``api-key`` or ``none``.
+    no_auth: bool, default: False
+        Whether the data transfer service requires no authentication. If set, this takes
+        precedence over ``auth_type`` and skips automatic API key negotiation.
     max_restarts: int, default: 5
         Maximum number of times to restart the worker if it crashes.
     """
@@ -190,6 +195,7 @@ class BinaryConfig:
         insecure: bool = False,
         debug: bool = False,
         auth_type: str = None,
+        no_auth: bool = False,
         env: dict | None = None,
         max_restarts: int = 5,
     ):
@@ -214,6 +220,7 @@ class BinaryConfig:
         self._env = env or {}
         self.insecure = insecure
         self.auth_type = auth_type
+        self.no_auth = no_auth
         self.max_restarts = max_restarts
 
         self._on_token_update = None
@@ -527,7 +534,9 @@ class Binary:
         if self._config.debug:
             self._args.append("--debug")
 
-        if self._config.auth_type:
+        if self._config.no_auth:
+            self._args.extend(["--auth-type", "none"])
+        elif self._config.auth_type:
             self._args.extend(
                 [
                     "--auth-type",

--- a/src/ansys/hps/data_transfer/client/client.py
+++ b/src/ansys/hps/data_transfer/client/client.py
@@ -618,6 +618,11 @@ class ClientBase:
         return
 
     def _adjust_config(self):
+        if self._bin_config.no_auth:
+            log.debug("no_auth is set, skipping auth auto-configuration")
+            self._bin_config.auth_type = "none"
+            return
+
         if not self._features:
             return
 

--- a/src/ansys/hps/data_transfer/client/client.py
+++ b/src/ansys/hps/data_transfer/client/client.py
@@ -619,7 +619,7 @@ class ClientBase:
 
     def _adjust_config(self):
         if self._bin_config.no_auth:
-            log.debug("no_auth is set, skipping auth auto-configuration")
+            log.info("No credentials provided - skipping authentication")
             self._bin_config.auth_type = "none"
             return
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,6 +26,7 @@ from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 import httpx
 import pytest
 
+from ansys.hps.data_transfer.client.binary import BinaryConfig
 from ansys.hps.data_transfer.client.client import AsyncClient, Client, ClientBase
 
 
@@ -280,6 +281,17 @@ class TestClientBase(unittest.TestCase):
         mock_getsize.assert_called_once_with("/path/to/panic_file.log")
         mock_log.error.assert_any_call("Worker panic file content:\nError: Something went wrong\n")
         mock_log.error.assert_any_call("Worker panic file content:\nDetails: Invalid configuration\n")
+
+    def test_adjust_config_no_auth_skips_api_key_negotiation(self):
+        """Test that _adjust_config respects no_auth and skips API key auto-negotiation."""
+        self.client._bin_config = BinaryConfig(no_auth=True)
+        self.client._features = ["auth_types.api_key", "auth_types.none"]
+
+        self.client._adjust_config()
+
+        assert self.client._bin_config.auth_type == "none"
+        assert self.client._api_key is None
+        assert self.client._bin_config.env == {}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This pull request introduces support for explicitly disabling authentication in the data transfer client by adding a new `no_auth` option to the `BinaryConfig` class. This allows users to bypass authentication and API key negotiation when interacting with services that do not require authentication. The changes include updating configuration, argument building, and client logic, as well as adding a unit test to ensure correct behavior.

**Testing:**

* Added a unit test to verify that setting `no_auth` in the client configuration correctly skips API key negotiation and sets the authentication type to `none`.
* Imported `BinaryConfig` in the test file to support the new test.

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.